### PR TITLE
Fixed chromosome comparison in createNormalizedCoverageFiles()

### DIFF
--- a/CoNVaDING.pl
+++ b/CoNVaDING.pl
@@ -2104,7 +2104,7 @@ sub createNormalizedCoverageFiles {
                     my $normautoControl=$linesControl[$normAutoIdxControl];
                     my $normsexControl=$linesControl[$normSexIdxControl];
                     my $keyControl = $lineControl;
-                    if ($chrSample == $chrControl && $startSample == $startControl && $stopSample == $stopControl){ #Check if chr, start and stop match, if not throw error and skip this file from analysis
+                    if ($chrSample eq $chrControl && $startSample == $startControl && $stopSample == $stopControl){ #Check if chr, start and stop match, if not throw error and skip this file from analysis
                         my $absDiffAuto = abs($normautoSample-$normautoControl); #Calculate absolute difference autosomal coverage
                         my $absDiffSex = abs($normsexSample-$normsexControl); #Calculate absolute difference all coverage
                         push(@absDiffsAuto, $absDiffAuto);


### PR DESCRIPTION
Chromosomes in BED and BAM files start with "chr". createNormalizedCoverageFiles() was trying to compare chromosome names in samples and control files as if these names were numerics. The subroutine now treats both as strings for comparison.